### PR TITLE
Simple Load Testing Script

### DIFF
--- a/cdn-load-test.sh
+++ b/cdn-load-test.sh
@@ -10,7 +10,7 @@ do
         for SIZE in $(echo $FILESIZES | sed "s/,/ /g");
         do
                 echo "Downloading $FILE"
-                wget https://yacdn.org/$1/http://speedtest.tele2.net/$SIZE.zip -O $WORKDIR/file.bin
+                wget -q https://yacdn.org/$1/http://speedtest.tele2.net/$SIZE.zip -O $WORKDIR/file.bin
                 rm $WORKDIR/file.bin
         done
 done

--- a/cdn-load-test.sh
+++ b/cdn-load-test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Usage: ./cdn-test.sh <serve/proxy> <number of iterations>
+
+WORKDIR='/tmp'
+FILESIZES='1MB,10MB,100MB,1GB'
+#Available: 1MB,10MB,100MB,1GB,10GB,50GB,100GB,1000GB
+
+for i in `seq 1 $2`;
+do
+        for SIZE in $(echo $FILESIZES | sed "s/,/ /g");
+        do
+                echo "Downloading $FILE"
+                wget https://yacdn.org/$1/http://speedtest.tele2.net/$SIZE.zip -O $WORKDIR/file.bin
+                rm $WORKDIR/file.bin
+        done
+done

--- a/cdn-load-test.sh
+++ b/cdn-load-test.sh
@@ -9,8 +9,12 @@ for i in `seq 1 $2`;
 do
         for SIZE in $(echo $FILESIZES | sed "s/,/ /g");
         do
-                echo "Downloading $FILE"
+                echo "Downloading $SIZE"
+                START=$(date +%s.%N)
                 wget -q https://yacdn.org/$1/http://speedtest.tele2.net/$SIZE.zip -O $WORKDIR/file.bin
+                END=$(date +%s.%N)
+                DIFF=$(echo "$END - $START" | bc)
+                echo "Downloaded $SIZE in $DIFF s"
                 rm $WORKDIR/file.bin
         done
 done


### PR DESCRIPTION
This bash script creates load on the CDN by iterating X times over the list of FILESIZES by downloading them.
You can specify either Proxy or Serve Mode.